### PR TITLE
build: Set `maven.compiler.release` to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <javadoc-plugin.version>3.2.0</javadoc-plugin.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
         <junit-platform.version>1.5.2</junit-platform.version>
-        <maven.compiler.release>12</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
         <mockito.version>3.3.3</mockito.version>
         <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This allows using coffee4j in projects that still depend on Java/JDK 11. In
contrast to Java 12 (its OpenJDK version is already EOL since
September 2019), Java 11 is an Long-Term-Support (LTS) release that is
supported until at least 2024-2027 (depending on the vendor).